### PR TITLE
Send selected-day PDF via email and fix exports

### DIFF
--- a/js/email.js
+++ b/js/email.js
@@ -1,21 +1,40 @@
 // ===== Envio de e-mails =====
 function enviarPDFManual() {
-  const hoje = formatarData(new Date());
-  const filtered = bancoHistorico.filter(item => item.data === hoje);
-  if (filtered.length === 0) {
-    alert("Nenhum histórico encontrado para hoje!");
+  const dataFiltro = document.getElementById("dataFiltro").value;
+  const dataTexto = dataFiltro ? converterDataInput(dataFiltro) : formatarData(new Date());
+  const registros = bancoHistorico.filter(item => item.data === dataTexto);
+  if (registros.length === 0) {
+    alert("Nenhum histórico encontrado para a data selecionada!");
     return;
   }
-  let mensagem = "📌 Histórico de Placas - " + hoje + "\n\n";
-  filtered.forEach(item => {
-    mensagem += `🚗 Placa: ${item.placa} | 👤 Nome: ${item.nome} | 🏷 Tipo: ${item.tipo} | 🆔 RG/CPF: ${item.rgcpf} | 📍 Status: ${item.status} | ⏰ Entrada: ${item.horarioEntrada || "-"} | ⏱ Saída: ${item.horarioSaida || "-"}\n`;
+  const { jsPDF } = window.jspdf;
+  const doc = new jsPDF();
+  doc.setFontSize(14);
+  doc.text("Histórico de Placas", 105, 15, null, null, "center");
+  let y = 25;
+  doc.setFontSize(12);
+  registros.forEach(item => {
+    doc.text(`Placa: ${item.placa} | Nome: ${item.nome} | Tipo: ${item.tipo} | RG/CPF: ${item.rgcpf} | Status: ${item.status} | Entrada: ${item.horarioEntrada || '-'} | Saída: ${item.horarioSaida || '-'}`, 10, y);
+    y += 8;
+    if (y > 280) { doc.addPage(); y = 20; }
   });
-  emailjs.send("service_t9bocqh", "template_n4uw7xi", {
-    to_email: "leomatos3914@gmail.com",
-    title: "Histórico Diário (Envio Manual)",
-    name: "Sistema de Placas",
-    message: mensagem
-  }).then(() => {
+  const pdfData = doc.output("datauristring");
+  const nomeArquivo = `historico-${dataTexto.replace(/\//g, '-')}.pdf`;
+  emailjs.send(
+    "service_t9bocqh",
+    "template_n4uw7xi",
+    {
+      to_email: "leomatos3914@gmail.com",
+      title: `Histórico Diário - ${dataTexto}`,
+      name: "Sistema de Placas",
+      message: `Histórico de Placas - ${dataTexto}`
+    },
+    {
+      attachments: [
+        { name: nomeArquivo, data: pdfData }
+      ]
+    }
+  ).then(() => {
     alert("📧 Histórico enviado manualmente com sucesso!");
   }).catch(err => {
     alert("❌ Erro ao enviar: " + JSON.stringify(err));
@@ -42,7 +61,7 @@ function enviarHistoricoDiario() {
   if (filtered.length === 0) return;
   let mensagem = "📌 Histórico de Placas - " + hoje + "\n\n";
   filtered.forEach(item => {
-    mensagem += `🚗 Placa: ${item.placa} | 👤 Nome: ${item.nome} | 🏷 Tipo: ${item.tipo} | 🆔 RG/CPF: ${item.rgcpf} | 📍 Status: ${item.status} | ⏰ Entrada: ${item.horarioEntrada || "-"} | ⏱ Saída: ${item.horarioSaida || "-"}\n`;
+    mensagem += `🚗 Placa: ${item.placa} | 👤 Nome: ${item.nome} | 🏷 Tipo: ${item.tipo} | 🆔 RG/CPF: ${item.rgcpf} | 📍 Status:${item.status} | ⏰ Entrada: ${item.horarioEntrada || "-"} | ⏱ Saída: ${item.horarioSaida || "-"}\n`;
   });
   emailjs.send("service_t9bocqh", "template_n4uw7xi", {
     to_email: "leomatos3914@gmail.com",
@@ -73,3 +92,4 @@ setInterval(() => {
 
 // Expondo globalmente
 window.enviarPDFManual = enviarPDFManual;
+

--- a/js/historico.js
+++ b/js/historico.js
@@ -43,29 +43,31 @@ function exportarCSV() {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `historico-${dataTexto}.csv`;
+  const nomeArquivo = `historico-${dataTexto.replace(/\//g, '-')}.csv`;
+  a.download = nomeArquivo;
   a.click();
   URL.revokeObjectURL(url);
   alert("Exportado com sucesso!");
 }
 
 function exportarPDF() {
+  const dataFiltro = document.getElementById("dataFiltro").value;
+  const dataTexto = dataFiltro ? converterDataInput(dataFiltro) : formatarData(new Date());
+  const registros = bancoHistorico.filter(item => item.data === dataTexto);
+  if (registros.length === 0) { alert("Nenhum dado para exportar."); return; }
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF();
-  const tabela = document.getElementById("listaHistorico");
-  if (tabela.innerHTML.trim() === "") { alert("Não há dados para exportar!"); return; }
   doc.setFontSize(14);
   doc.text("Histórico de Placas", 105, 15, null, null, "center");
-  let y = 20;
-  const rows = tabela.querySelectorAll(".item");
-  rows.forEach((row) => {
-    doc.setFontSize(12);
-    doc.text(row.innerText.split("\n").join(" | "), 10, y);
+  let y = 25;
+  doc.setFontSize(12);
+  registros.forEach(item => {
+    doc.text(`Placa: ${item.placa} | Nome: ${item.nome} | Tipo: ${item.tipo} | RG/CPF: ${item.rgcpf} | Status: ${item.status} | Entrada: ${item.horarioEntrada || '-'} | Saída: ${item.horarioSaida || '-'}`, 10, y);
     y += 8;
     if (y > 280) { doc.addPage(); y = 20; }
   });
-  const dataHoje = new Date().toISOString().split("T")[0];
-  doc.save(`historico-${dataHoje}.pdf`);
+  const nomeArquivo = `historico-${dataTexto.replace(/\//g, '-')}.pdf`;
+  doc.save(nomeArquivo);
 }
 
 function checarExportacaoAutomaticaPDF() {


### PR DESCRIPTION
## Summary
- Export CSV and PDF with sanitized filenames filtered by chosen date
- Allow manual email to attach PDF report for the selected day

## Testing
- `npx jshint js/email.js js/historico.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5aed35a88332880436c4c2772c39