### PR TITLE
Send selected-day PDF via email and fix exports

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,9 @@
 
   <!-- EmailJS -->
   <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"></script>
-<script type="text/javascript">
-  (function() {
-    emailjs.init("vPVpXFO3k8QblVbqr"); //  public key
-  })();
-</script>
 
   <!-- jsPDF -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 <script>
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('sw.js').then(() => {

--- a/js/email.js
+++ b/js/email.js
@@ -1,21 +1,47 @@
 // ===== Envio de e-mails =====
+const EMAILJS_PUBLIC_KEY = "vPVpKP3k8QbXQbqr"; // substitua pela sua Public Key
+
+emailjs.init({ publicKey: EMAILJS_PUBLIC_KEY });
+
 function enviarPDFManual() {
-  const hoje = formatarData(new Date());
-  const filtered = bancoHistorico.filter(item => item.data === hoje);
-  if (filtered.length === 0) {
-    alert("Nenhum histórico encontrado para hoje!");
+  const dataFiltro = document.getElementById("dataFiltro").value;
+  const dataTexto = dataFiltro ? converterDataInput(dataFiltro) : formatarData(new Date());
+  const registros = bancoHistorico.filter(item => item.data === dataTexto);
+  if (registros.length === 0) {
+    alert("Nenhum histórico encontrado para a data selecionada!");
     return;
   }
-  let mensagem = "📌 Histórico de Placas - " + hoje + "\n\n";
-  filtered.forEach(item => {
-    mensagem += `🚗 Placa: ${item.placa} | 👤 Nome: ${item.nome} | 🏷 Tipo: ${item.tipo} | 🆔 RG/CPF: ${item.rgcpf} | 📍 Status: ${item.status} | ⏰ Entrada: ${item.horarioEntrada || "-"} | ⏱ Saída: ${item.horarioSaida || "-"}\n`;
+
+  if (!window.jspdf || !window.jspdf.jsPDF) {
+    alert("Biblioteca jsPDF não carregada!");
+    return;
+  }
+  const { jsPDF } = window.jspdf;
+
+  const doc = new jsPDF();
+  doc.setFontSize(14);
+  doc.text("Histórico de Placas", 105, 15, null, null, "center");
+  let y = 25;
+  doc.setFontSize(12);
+  registros.forEach(item => {
+    doc.text(`Placa: ${item.placa} | Nome: ${item.nome} | Tipo: ${item.tipo} | RG/CPF: ${item.rgcpf} | Status: ${item.status} | Entrada: ${item.horarioEntrada || '-'} | Saída: ${item.horarioSaida || '-'}`, 10, y);
+    y += 8;
+    if (y > 280) { doc.addPage(); y = 20; }
   });
-  emailjs.send("service_t9bocqh", "template_n4uw7xi", {
-    to_email: "leomatos3914@gmail.com",
-    title: "Histórico Diário (Envio Manual)",
-    name: "Sistema de Placas",
-    message: mensagem
-  }).then(() => {
+
+  const pdfDataUri = doc.output("datauristring");
+
+  emailjs.send(
+    "service_t9bocqh",
+    "template_n4uw7xi",
+    {
+      to_email: "leomatos3914@gmail.com",
+      title: `Histórico Diário - ${dataTexto}`,
+      name: "Sistema de Placas",
+      message: `Histórico de Placas - ${dataTexto}`,
+      attachment: pdfDataUri
+    }
+  ).then(() => {
     alert("📧 Histórico enviado manualmente com sucesso!");
   }).catch(err => {
     alert("❌ Erro ao enviar: " + JSON.stringify(err));
@@ -42,14 +68,18 @@ function enviarHistoricoDiario() {
   if (filtered.length === 0) return;
   let mensagem = "📌 Histórico de Placas - " + hoje + "\n\n";
   filtered.forEach(item => {
-    mensagem += `🚗 Placa: ${item.placa} | 👤 Nome: ${item.nome} | 🏷 Tipo: ${item.tipo} | 🆔 RG/CPF: ${item.rgcpf} | 📍 Status: ${item.status} | ⏰ Entrada: ${item.horarioEntrada || "-"} | ⏱ Saída: ${item.horarioSaida || "-"}\n`;
+    mensagem += `🚗 Placa: ${item.placa} | 👤 Nome: ${item.nome} | 🏷 Tipo: ${item.tipo} | 🆔 RG/CPF: ${item.rgcpf} | 📍 Status:${item.status} | ⏰ Entrada: ${item.horarioEntrada || "-"} | ⏱ Saída: ${item.horarioSaida || "-"}\n`;
   });
-  emailjs.send("service_t9bocqh", "template_n4uw7xi", {
-    to_email: "leomatos3914@gmail.com",
-    message: mensagem,
-    title: "Histórico Diário",
-    name: "Sistema de Placas"
-  }).then(() => {
+  emailjs.send(
+    "service_t9bocqh",
+    "template_n4uw7xi",
+    {
+      to_email: "leomatos3914@gmail.com",
+      message: mensagem,
+      title: "Histórico Diário",
+      name: "Sistema de Placas"
+    }
+  ).then(() => {
     console.log("✅ Histórico do dia enviado por e-mail.");
     marcarEnvio();
   }).catch(err => {

--- a/js/historico.js
+++ b/js/historico.js
@@ -43,29 +43,36 @@ function exportarCSV() {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = `historico-${dataTexto}.csv`;
+  const nomeArquivo = `historico-${dataTexto.replace(/\//g, '-')}.csv`;
+  a.download = nomeArquivo;
   a.click();
   URL.revokeObjectURL(url);
   alert("Exportado com sucesso!");
 }
 
 function exportarPDF() {
+  const dataFiltro = document.getElementById("dataFiltro").value;
+  const dataTexto = dataFiltro ? converterDataInput(dataFiltro) : formatarData(new Date());
+  const registros = bancoHistorico.filter(item => item.data === dataTexto);
+  if (registros.length === 0) { alert("Nenhum dado para exportar."); return; }
+  if (!window.jspdf || !window.jspdf.jsPDF) {
+    alert("Biblioteca jsPDF não carregada!");
+    return;
+  }
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF();
-  const tabela = document.getElementById("listaHistorico");
-  if (tabela.innerHTML.trim() === "") { alert("Não há dados para exportar!"); return; }
   doc.setFontSize(14);
   doc.text("Histórico de Placas", 105, 15, null, null, "center");
-  let y = 20;
-  const rows = tabela.querySelectorAll(".item");
-  rows.forEach((row) => {
-    doc.setFontSize(12);
-    doc.text(row.innerText.split("\n").join(" | "), 10, y);
+  let y = 25;
+  doc.setFontSize(12);
+  registros.forEach(item => {
+    doc.text(`Placa: ${item.placa} | Nome: ${item.nome} | Tipo: ${item.tipo} | RG/CPF: ${item.rgcpf} | Status: ${item.status} | Entrada: ${item.horarioEntrada || '-'} | Saída: ${item.horarioSaida || '-'}`, 10, y);
     y += 8;
     if (y > 280) { doc.addPage(); y = 20; }
   });
-  const dataHoje = new Date().toISOString().split("T")[0];
-  doc.save(`historico-${dataHoje}.pdf`);
+  const nomeArquivo = `historico-${dataTexto.replace(/\//g, '-')}.pdf`;
+  doc.save(nomeArquivo);
+  alert("Exportado com sucesso!");
 }
 
 function checarExportacaoAutomaticaPDF() {


### PR DESCRIPTION
## Summary
- Initialize EmailJS in code and send selected-day history PDF using the `attachment` parameter
- Simplify EmailJS script loading to avoid missing public key errors

## Testing
- `npx jshint js/email.js js/historico.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5aed35a88332880436c4c2772c39