### PR TITLE
Improve PDF export formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 
   <!-- jsPDF -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
 <script>
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('sw.js').then(() => {


### PR DESCRIPTION
## Summary
- Add jspdf-autotable library
- Export history using table with column widths, header and footer

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6cc135748332897a0f16521c5db1