### PR TITLE
Add EmailJS send and export PDF buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
   <!-- jsPDF -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.28/jspdf.plugin.autotable.min.js"></script>
+  <!-- EmailJS -->
+  <script src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"></script>
 <script>
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('sw.js').then(() => {
@@ -83,6 +85,7 @@ if ('serviceWorker' in navigator) {
   <div id="listaHistorico" class="lista"></div>
   <button id="exportBtn" onclick="exportarCSV()">Exportar CSV</button>
   <button onclick="exportarPDF()">Exportar PDF</button>
+  <button onclick="enviarEmail()">Enviar Email</button>
 </div>
 
 <!-- scripts separados -->


### PR DESCRIPTION
## Summary
- Add "Enviar Email" button that generates and emails PDF via EmailJS
- Configure EmailJS with provided service, template, and public key
- Reuse a single PDF generator for both exporting and emailing reports

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6ecf6df08332b29b4990c72b9768