### PR TITLE
feat: send daily email via service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,21 @@
   <script src="https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js"></script>
 <script>
 if ('serviceWorker' in navigator) {
-  navigator.serviceWorker.register('sw.js').then(() => {
+  navigator.serviceWorker.register('sw.js').then(async (registration) => {
     console.log('Service Worker registrado!');
+    if ('periodicSync' in registration) {
+      try {
+        const status = await navigator.permissions.query({ name: 'periodic-background-sync' });
+        if (status.state === 'granted') {
+          await registration.periodicSync.register('daily-email', {
+            minInterval: 24 * 60 * 60 * 1000,
+          });
+          console.log('Periodic Sync registrado!');
+        }
+      } catch (err) {
+        console.error('Erro ao registrar periodic sync', err);
+      }
+    }
   });
 }
 </script>

--- a/sw.js
+++ b/sw.js
@@ -1,3 +1,6 @@
+importScripts('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js');
+importScripts('https://cdn.jsdelivr.net/npm/@emailjs/browser@3/dist/email.min.js');
+
 const CACHE_NAME = 'placas-cache-v1';
 const URLS_TO_CACHE = [
   '/',
@@ -16,5 +19,36 @@ self.addEventListener('fetch', (event) => {
   event.respondWith(
     caches.match(event.request).then((response) => response || fetch(event.request))
   );
+});
+
+// ===== Agendamento de envio diário de e-mail =====
+const EMAILJS_SERVICE_ID = 'service_t9bocqh';
+const EMAILJS_TEMPLATE_ID = 'template_n4uw7xi';
+const EMAILJS_PUBLIC_KEY = 'vPVpXFO3k8QblVbqr';
+
+emailjs.init(EMAILJS_PUBLIC_KEY);
+
+async function enviarEmailDiario() {
+  try {
+    const { jsPDF } = self.jspdf;
+    const doc = new jsPDF();
+    doc.text('Histórico diário', 10, 10);
+    const pdfDataUri = doc.output('datauristring');
+
+    await emailjs.send(EMAILJS_SERVICE_ID, EMAILJS_TEMPLATE_ID, {
+      to_email: 'seu-email@example.com',
+      message: 'Envio automático diário',
+      attachment: pdfDataUri,
+    });
+    console.log('E-mail diário enviado');
+  } catch (err) {
+    console.error('Falha ao enviar e-mail diário', err);
+  }
+}
+
+self.addEventListener('periodicsync', (event) => {
+  if (event.tag === 'daily-email') {
+    event.waitUntil(enviarEmailDiario());
+  }
 });
 


### PR DESCRIPTION
## Summary
- register periodic background sync to send emails daily
- add service worker logic to generate PDF and email it via EmailJS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb788c08c483328a72ba6565279bd2