### PR TITLE
Support external history PDF for daily emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ EMAILJS_TEMPLATE_ID=template_n4uw7xi
 EMAILJS_PUBLIC_KEY=vPVpXFO3k8QblVbqr
 EMAILJS_PRIVATE_KEY=hsqyhUKSulS8bEBmEsMyy
 EMAILJS_RECIPIENTS=leomatos3914@gmail.com
+HISTORY_PDF_URL=https://example.com/history.pdf

--- a/.github/workflows/daily-email.yml
+++ b/.github/workflows/daily-email.yml
@@ -21,3 +21,4 @@ jobs:
           EMAILJS_PUBLIC_KEY: ${{ secrets.EMAILJS_PUBLIC_KEY }}
           EMAILJS_PRIVATE_KEY: ${{ secrets.EMAILJS_PRIVATE_KEY }}
           EMAILJS_RECIPIENTS: ${{ secrets.EMAILJS_RECIPIENTS }}
+          HISTORY_PDF_URL: ${{ secrets.HISTORY_PDF_URL }}

--- a/scripts/daily-email.js
+++ b/scripts/daily-email.js
@@ -43,7 +43,19 @@ async function sendEmail(pdfBuffer) {
 }
 
 export async function runDailyEmail() {
-  const pdf = await generatePdf();
+  let pdf;
+  if (process.env.HISTORY_PDF_URL) {
+    const res = await fetch(process.env.HISTORY_PDF_URL);
+    if (!res.ok) {
+      throw new Error(
+        `Failed to fetch HISTORY_PDF_URL: ${res.status} ${res.statusText}`
+      );
+    }
+    pdf = Buffer.from(await res.arrayBuffer());
+  } else {
+    pdf = await generatePdf();
+  }
+
   await sendEmail(pdf);
   console.log('Daily email sent');
 }


### PR DESCRIPTION
## Summary
- Fetch optional HISTORY_PDF_URL and send its PDF buffer in daily email
- Document HISTORY_PDF_URL in env example
- Pass HISTORY_PDF_URL secret in daily email workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb8c4047148332a78d53527cf1b3d4