### PR TITLE
Implement automatic PDF report email scheduling

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -8,6 +8,9 @@ function atualizarTudo(){
 
 mostrarPagina('inicioContainer');
 atualizarTudo();
-window.addEventListener("load", checarExportacaoAutomaticaPDF);
+window.addEventListener("load", () => {
+  checarExportacaoAutomaticaPDF();
+  processarRelatoriosPendentes();
+});
 // garante que bancos estejam persistidos
 salvarBanco();


### PR DESCRIPTION
## Summary
- Track last sent report date in localStorage
- Process and email pending daily reports automatically
- Schedule automatic email for current day at 23:59

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb95e7aba08332b35a7b9cf0bed39e