### PR TITLE
Cache historico by date and optimize report generation

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -3,6 +3,32 @@ let bancoCadastros = JSON.parse(localStorage.getItem("bancoCadastros")) || [];
 let bancoHistorico = JSON.parse(localStorage.getItem("bancoHistorico")) || [];
 let bancoAutorizados = JSON.parse(localStorage.getItem("bancoAutorizados")) || [];
 
+// Mapa {dateISO: [registros]} do histórico
+let bancoHistoricoMap = {};
+
+// Reconstrói o mapa a partir do array
+function rebuildHistoricoMap() {
+  bancoHistoricoMap = {};
+  bancoHistorico.forEach(r => {
+    const iso = r.data.split("/").reverse().join("-");
+    if (!bancoHistoricoMap[iso]) bancoHistoricoMap[iso] = [];
+    bancoHistoricoMap[iso].push(r);
+  });
+  // expõe o mapa sempre atualizado
+  window.bancoHistoricoMap = bancoHistoricoMap;
+}
+
+rebuildHistoricoMap();
+
+// Adiciona um novo registro ao histórico e atualiza o mapa
+function adicionarHistorico(registro) {
+  bancoHistorico.push(registro);
+  const iso = registro.data.split("/").reverse().join("-");
+  if (!bancoHistoricoMap[iso]) bancoHistoricoMap[iso] = [];
+  bancoHistoricoMap[iso].push(registro);
+  salvarBanco();
+}
+
 function salvarBanco() {
   localStorage.setItem("bancoCadastros", JSON.stringify(bancoCadastros));
   localStorage.setItem("bancoHistorico", JSON.stringify(bancoHistorico));
@@ -14,3 +40,5 @@ window.bancoCadastros = bancoCadastros;
 window.bancoHistorico = bancoHistorico;
 window.bancoAutorizados = bancoAutorizados;
 window.salvarBanco = salvarBanco;
+window.adicionarHistorico = adicionarHistorico;
+window.rebuildHistoricoMap = rebuildHistoricoMap;

--- a/js/historico.js
+++ b/js/historico.js
@@ -21,10 +21,12 @@ function converterDataInput(input) {
 
 function filtrarHistorico() {
   const input = document.getElementById("dataFiltro").value;
-  const dataFiltro = input ? converterDataInput(input) : formatarData(new Date());
+  const dataISO = input || new Date().toISOString().split("T")[0];
+  const dataFiltro = converterDataInput(dataISO);
   const listaDiv = document.getElementById("listaHistorico");
   listaDiv.innerHTML = "";
-  bancoHistorico.filter(i => i.data === dataFiltro).forEach(item => {
+  const registros = bancoHistoricoMap[dataISO] || [];
+  registros.forEach(item => {
     let cor = item.status === "Em andamento" ? "red" : item.status === "Finalizado" ? "green" : "black";
     listaDiv.innerHTML += `<div class="item"><b>${item.placa}</b> - ${item.nome} [${item.tipo}] - RG/CPF: ${item.rgcpf}<br>Data:${item.data}<br>Status:<span style="color:${cor}">${item.status}</span><br>Entrada:<span class="horaEntrada">${item.horarioEntrada || "-"}</span>|Saída:<span class="horaSaida">${item.horarioSaida || "-"}</span></div>`;
   });
@@ -32,11 +34,12 @@ function filtrarHistorico() {
 
 function exportarCSV() {
   const dataFiltro = document.getElementById("dataFiltro").value;
-  const dataTexto = dataFiltro ? converterDataInput(dataFiltro) : formatarData(new Date());
-  const filtered = bancoHistorico.filter(item => item.data === dataTexto);
-  if (filtered.length === 0) { alert("Nenhum dado para exportar."); return; }
+  const dataISO = dataFiltro || new Date().toISOString().split("T")[0];
+  const dataTexto = converterDataInput(dataISO);
+  const registros = bancoHistoricoMap[dataISO] || [];
+  if (registros.length === 0) { alert("Nenhum dado para exportar."); return; }
   let csv = "Placa,Nome,Tipo,RG/CPF,Data,Status,Entrada,Saída\n";
-  filtered.forEach(item => {
+  registros.forEach(item => {
     csv += `${item.placa},${item.nome},${item.tipo},${item.rgcpf},${item.data},${item.status},${item.horarioEntrada || '-'},${item.horarioSaida || '-'}\n`;
   });
   const blob = new Blob([csv], { type: 'text/csv' });
@@ -110,8 +113,9 @@ function gerarRelatorioPDF(registros, dataRelatorio) {
 
 function exportarPDF() {
   const dataFiltro = document.getElementById("dataFiltro").value;
-  const dataTexto = dataFiltro ? converterDataInput(dataFiltro) : formatarData(new Date());
-  const registros = bancoHistorico.filter(item => item.data === dataTexto);
+  const dataISO = dataFiltro || new Date().toISOString().split("T")[0];
+  const dataTexto = converterDataInput(dataISO);
+  const registros = bancoHistoricoMap[dataISO] || [];
   if (registros.length === 0) { alert("Nenhum dado para exportar."); return; }
 
   const nomeArquivo = `historico-${dataTexto.replace(/\//g, '-')}.pdf`;
@@ -125,8 +129,9 @@ function exportarPDF() {
 
 function enviarEmail() {
   const dataFiltro = document.getElementById("dataFiltro").value;
-  const dataTexto = dataFiltro ? converterDataInput(dataFiltro) : formatarData(new Date());
-  const registros = bancoHistorico.filter(item => item.data === dataTexto);
+  const dataISO = dataFiltro || new Date().toISOString().split("T")[0];
+  const dataTexto = converterDataInput(dataISO);
+  const registros = bancoHistoricoMap[dataISO] || [];
   if (registros.length === 0) { alert("Nenhum dado para enviar."); return; }
 
 
@@ -141,7 +146,6 @@ function enviarEmail() {
 
   }).then(() => {
     alert("PDF enviado com sucesso!");
-    const dataISO = dataTexto.split("/").reverse().join("-");
     localStorage.setItem("ultimoRelatorioEnviado", dataISO);
   }).catch(err => {
     console.error("Erro ao enviar PDF:", err);
@@ -177,12 +181,10 @@ async function processarRelatoriosPendentes() {
     proxima = new Date(ultimo);
     proxima.setDate(proxima.getDate() + 1);
   } else {
-    // Busca a primeira data existente no histórico
-    proxima = bancoHistorico.reduce((min, item) => {
-      const [d, m, a] = item.data.split("/").map(Number);
-      const dt = new Date(a, m - 1, d);
-      return (!min || dt < min) ? dt : min;
-    }, null);
+    const datas = Object.keys(bancoHistoricoMap).sort();
+    if (datas.length > 0) {
+      proxima = new Date(datas[0]);
+    }
   }
 
   if (!proxima) {
@@ -192,8 +194,8 @@ async function processarRelatoriosPendentes() {
 
   while (proxima <= ontem) {
     const dataISO = proxima.toISOString().split("T")[0];
-    const dataTexto = formatarData(proxima);
-    const registros = bancoHistorico.filter(i => i.data === dataTexto);
+    const dataTexto = converterDataInput(dataISO);
+    const registros = bancoHistoricoMap[dataISO] || [];
     try {
       if (registros.length > 0) {
         const doc = gerarRelatorioPDF(registros, dataTexto);
@@ -221,8 +223,8 @@ function agendarEnvioHoje() {
   if (ms <= 0) return;
   setTimeout(async () => {
     const hojeISO = new Date().toISOString().split("T")[0];
-    const hojeTexto = formatarData(new Date());
-    const registros = bancoHistorico.filter(i => i.data === hojeTexto);
+    const hojeTexto = converterDataInput(hojeISO);
+    const registros = bancoHistoricoMap[hojeISO] || [];
     if (registros.length > 0) {
       const doc = gerarRelatorioPDF(registros, hojeTexto);
       if (doc) {
@@ -245,10 +247,12 @@ function checarExportacaoAutomaticaPDF() {
     const horas24 = 24 * 60 * 60 * 1000;
     if (diff >= horas24) { dataInicio = ultima; } else { return; }
   } else { dataInicio = new Date(agora.getTime() - 24 * 60 * 60 * 1000); }
-  const historicoFiltrado = bancoHistorico.filter(item => {
-    const [dia, mes, ano] = item.data.split("/").map(Number);
-    const dataItem = new Date(ano, mes - 1, dia);
-    return dataItem > dataInicio;
+  const historicoFiltrado = [];
+  Object.keys(bancoHistoricoMap).forEach(iso => {
+    const dataItem = new Date(iso);
+    if (dataItem > dataInicio) {
+      historicoFiltrado.push(...bancoHistoricoMap[iso]);
+    }
   });
   if (historicoFiltrado.length === 0) return;
   const dataHoje = new Date().toISOString().split("T")[0];
@@ -321,6 +325,10 @@ importInput.addEventListener("change", (event) => {
       bancoCadastros = dados.bancoCadastros;
       bancoHistorico = dados.bancoHistorico;
       bancoAutorizados = dados.bancoAutorizados;
+      window.bancoCadastros = bancoCadastros;
+      window.bancoHistorico = bancoHistorico;
+      window.bancoAutorizados = bancoAutorizados;
+      rebuildHistoricoMap();
       salvarBanco();
       atualizarCadastros();
       atualizarTabelaAndamento();

--- a/js/placas.js
+++ b/js/placas.js
@@ -65,7 +65,7 @@ function marcarEntradaComTipo(placa) {
   const cadastro = bancoCadastros.find(i => i.placa === placa) || bancoAutorizados.find(i => i.placa === placa);
   if (!cadastro) return;
   const hoje = formatarData(new Date());
-  bancoHistorico.push({
+  adicionarHistorico({
     nome: cadastro.nome,
     placa: cadastro.placa,
     rgcpf: cadastro.rgcpf,
@@ -75,7 +75,6 @@ function marcarEntradaComTipo(placa) {
     horarioEntrada: new Date().toLocaleTimeString(),
     horarioSaida: ""
   });
-  salvarBanco();
   atualizarTabelaAndamento();
   filtrarHistorico();
   fecharPopup();
@@ -89,8 +88,7 @@ function entradaNovaPlaca(placa) {
   if (!nome || !rgcpf || !tipo || !placa) { alert("Preencha todos os campos!"); return; }
   const hoje = formatarData(new Date());
   bancoCadastros.push({ nome, placa, rgcpf, tipo });
-  bancoHistorico.push({ nome, placa, rgcpf, tipo, status: "Em andamento", data: hoje, horarioEntrada: new Date().toLocaleTimeString(), horarioSaida: "" });
-  salvarBanco();
+  adicionarHistorico({ nome, placa, rgcpf, tipo, status: "Em andamento", data: hoje, horarioEntrada: new Date().toLocaleTimeString(), horarioSaida: "" });
   atualizarCadastros();
   atualizarTabelaAndamento();
   filtrarHistorico();
@@ -104,8 +102,7 @@ function marcarEntrada(placa) {
   const cadastro = bancoCadastros.find(i => i.placa === placa) || bancoAutorizados.find(i => i.placa === placa);
   if (!cadastro) return;
   const hoje = formatarData(new Date());
-  bancoHistorico.push({ nome: cadastro.nome, placa: cadastro.placa, rgcpf: cadastro.rgcpf, tipo: cadastro.tipo || "Autorizado", status: "Em andamento", data: hoje, horarioEntrada: new Date().toLocaleTimeString(), horarioSaida: "" });
-  salvarBanco();
+  adicionarHistorico({ nome: cadastro.nome, placa: cadastro.placa, rgcpf: cadastro.rgcpf, tipo: cadastro.tipo || "Autorizado", status: "Em andamento", data: hoje, horarioEntrada: new Date().toLocaleTimeString(), horarioSaida: "" });
   atualizarTabelaAndamento();
   filtrarHistorico();
   fecharPopup();

--- a/js/ui.js
+++ b/js/ui.js
@@ -29,7 +29,9 @@ function limparTudo() {
   if (senha === "1234") {
     if (confirm("Deseja realmente limpar o histórico e mensagens?")) {
       bancoHistorico = [];
-      localStorage.setItem("bancoHistorico", JSON.stringify(bancoHistorico));
+      window.bancoHistorico = bancoHistorico;
+      rebuildHistoricoMap();
+      salvarBanco();
       document.getElementById("mensagem").innerHTML = "";
       atualizarTabelaAndamento();
       filtrarHistorico();


### PR DESCRIPTION
## Summary
- build a global date-indexed map of historical records and keep it in sync when adding entries
- use the cached map for CSV/PDF generation and email/report routines instead of filtering the full array
- rebuild the map on data imports or resets to keep global state consistent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb9a5f2bac83328ba80b11b59dbb6d