### PR TITLE
Prevent manual email from updating last send date

### DIFF
--- a/js/historico.js
+++ b/js/historico.js
@@ -63,6 +63,15 @@ if (window.emailjs) {
 }
 
 
+// Armazena a data do último relatório enviado automaticamente
+let ultimoRelatorioEnviado = localStorage.getItem("ultimoRelatorioEnviado") || null;
+
+function salvarUltimoRelatorioEnviado(data) {
+  ultimoRelatorioEnviado = data;
+  localStorage.setItem("ultimoRelatorioEnviado", data);
+}
+
+
 }
 
 function gerarRelatorioPDF(registros, dataRelatorio) {
@@ -189,6 +198,7 @@ function enviarEmailAutomatico(pdfDataUri, data) {
     console.log(`Relatório de ${data} enviado automaticamente.`);
     relatoriosEnviados[data] = true;
     salvarRelatoriosEnviados();
+    salvarUltimoRelatorioEnviado(data);
   }).catch(err => {
     console.error(`Erro ao enviar relatório automático de ${data}:`, err);
     const fila = obterPendenciasEnvio();


### PR DESCRIPTION
## Summary
- Track last automatically sent report date in localStorage
- Update this value only when `enviarEmailAutomatico` succeeds
- Manual `enviarEmail` no longer mutates daily-send state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb9bd06ed88332861ab0668675cfd3